### PR TITLE
chore: add minimal hello world workflow to verify Actions scheduling

### DIFF
--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -1,0 +1,11 @@
+name: Hello Actions
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hello:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Say hello
+        run: echo "Hello from Actions on ${{ github.repository }} @ ${{ github.ref }}"


### PR DESCRIPTION
Adds `.github/workflows/hello.yml` with a single inline job that echoes context. This helps confirm whether job scheduling is working for this repo.

After merge, trigger "Hello Actions" via workflow_dispatch. If it runs, reusable workflows should also be permitted; otherwise, the failure is pre-job scheduling.