### PR TITLE
ci: point debug reusable workflow to @main

### DIFF
--- a/.github/workflows/debug-policy.yml
+++ b/.github/workflows/debug-policy.yml
@@ -15,7 +15,7 @@ jobs:
           echo "Inline job reached. Event=${{ github.event_name }} Repo=${{ github.repository }} Ref=${{ github.ref }}"
   reuse:
     needs: inline
-    uses: rishitank/auggie-dependabot/.github/workflows/auggie.yml@v1
+    uses: rishitank/auggie-dependabot/.github/workflows/auggie.yml@main
     with:
       pr-labels: 'debug'
       auggie-config-path: '.auggie.yml'


### PR DESCRIPTION
Update debug-policy.yml to reference the local reusable workflow using @main instead of @v1. This ensures we call the file that exists in this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to reference the latest reusable workflow from the main branch, improving alignment with current infrastructure and easing future maintenance.
  * No changes to product features or behaviour; this is a behind-the-scenes configuration update intended to keep automation up to date and consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->