### PR TITLE
ci(auggie.yml): fix YAML parse error by indenting heredoc content

### DIFF
--- a/.github/workflows/auggie.yml
+++ b/.github/workflows/auggie.yml
@@ -84,17 +84,17 @@ jobs:
 
           # Create instruction for Auggie automation
           cat > .auggie-instruction.md <<'EOT'
-You are Auggie, an AI upgrade agent.
-Task: Detect and apply dependency/version updates across all ecosystems in this repository. Where breaking changes are required, attempt safe code refactors/codemods to avoid regressions. Keep lockfiles in sync. If a full migration is required, output a clear migration plan with incremental steps.
+          You are Auggie, an AI upgrade agent.
+          Task: Detect and apply dependency/version updates across all ecosystems in this repository. Where breaking changes are required, attempt safe code refactors/codemods to avoid regressions. Keep lockfiles in sync. If a full migration is required, output a clear migration plan with incremental steps.
 
-Requirements:
-- Auto-detect ecosystems (npm/yarn/pnpm, pip/poetry, go, cargo, maven/gradle, actions, docker, etc.).
-- Prefer non-breaking upgrades; for breaking changes, update code and configs safely.
-- Do not delete unrelated files. Avoid destructive operations.
-- After changes, write a concise Markdown changelog to .auggie-changelog.md.
-- If a full migration is needed, write details to migration-plan.md.
-- Be verbose about what changed: packages, versions, code refactors.
-EOT
+          Requirements:
+          - Auto-detect ecosystems (npm/yarn/pnpm, pip/poetry, go, cargo, maven/gradle, actions, docker, etc.).
+          - Prefer non-breaking upgrades; for breaking changes, update code and configs safely.
+          - Do not delete unrelated files. Avoid destructive operations.
+          - After changes, write a concise Markdown changelog to .auggie-changelog.md.
+          - If a full migration is needed, write details to migration-plan.md.
+          - Be verbose about what changed: packages, versions, code refactors.
+          EOT
 
           echo "Running Auggie in print mode with instruction file"
           # Prefer npx invocation for the scoped package


### PR DESCRIPTION
Fix the YAML parse error reported in Actions for the reusable workflow by indenting the heredoc content inside the run block. The unindented literal text was being parsed as YAML at the same indentation level, causing: "You have an error in your yaml syntax on line 87".

Change:
- Indent the content between `cat > .auggie-instruction.md <<'EOT'` and `EOT` so the block remains inside the shell script.

After merge:
- Re-run Self Test (Auggie Reusable) and the Debug workflow (if present). They should now schedule jobs normally, assuming AUGMENT_SESSION_AUTH repo secret exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted instruction content used by the automation workflow for consistency and clearer structure. No changes to behaviour, triggers, or outputs.
* **Chores**
  * Minor CI maintenance to improve readability of generated instructions within the workflow. No user-facing impact or modifications to features, APIs, or performance.
* **Documentation**
  * Internal instruction text made more readable within the workflow context.
  
No user-facing changes; application behaviour remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->