### PR TITLE
ci: resolve auggie.yml conflict; default model gpt5 across workflows; robust instruction write

### DIFF
--- a/.github/workflows/auggie.yml
+++ b/.github/workflows/auggie.yml
@@ -76,25 +76,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUGMENT_SESSION_AUTH: ${{ secrets.AUGMENT_SESSION_AUTH }}
+          INSTRUCTION: |
+            You are Auggie, an AI upgrade agent.
+            Task: Detect and apply dependency/version updates across all ecosystems in this repository. Where breaking changes are required, attempt safe code refactors/codemods to avoid regressions. Keep lockfiles in sync. If a full migration is required, output a clear migration plan with incremental steps.
+
+            Requirements:
+            - Auto-detect ecosystems (npm/yarn/pnpm, pip/poetry, go, cargo, maven/gradle, actions, docker, etc.).
+            - Prefer non-breaking upgrades; for breaking changes, update code and configs safely.
+            - Do not delete unrelated files. Avoid destructive operations.
+            - After changes, write a concise Markdown changelog to .auggie-changelog.md.
+            - If a full migration is needed, write details to migration-plan.md.
+            - Be verbose about what changed: packages, versions, code refactors.
+
         shell: bash
         run: |
           set -euo pipefail
           CONFIG='${{ inputs["auggie-config-path"] }}'
           EXTRA='${{ inputs["auggie-run-args"] }}'
 
-          # Create instruction for Auggie automation
-          cat > .auggie-instruction.md <<'EOT'
-You are Auggie, an AI upgrade agent.
-Task: Detect and apply dependency/version updates across all ecosystems in this repository. Where breaking changes are required, attempt safe code refactors/codemods to avoid regressions. Keep lockfiles in sync. If a full migration is required, output a clear migration plan with incremental steps.
-
-Requirements:
-- Auto-detect ecosystems (npm/yarn/pnpm, pip/poetry, go, cargo, maven/gradle, actions, docker, etc.).
-- Prefer non-breaking upgrades; for breaking changes, update code and configs safely.
-- Do not delete unrelated files. Avoid destructive operations.
-- After changes, write a concise Markdown changelog to .auggie-changelog.md.
-- If a full migration is needed, write details to migration-plan.md.
-- Be verbose about what changed: packages, versions, code refactors.
-EOT
+          # Create instruction for Auggie automation (using env INSTRUCTION YAML block)
+          printf "%s\n" "$INSTRUCTION" > .auggie-instruction.md
 
           echo "Running Auggie in print mode with instruction file"
           # Prefer npx invocation for the scoped package


### PR DESCRIPTION
Resolve merge conflict against main in auggie.yml by keeping the env+printf approach (no heredoc). Also set default model to gpt5 across workflows.